### PR TITLE
create entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ RUN pip install -r requirements.txt
 COPY . . 
 RUN pip install --editable .
 RUN touch previous_cards.db
-RUN caribou upgrade previous_cards.db ./migrations
-CMD ["python", "-m", "src"]
+ENTRYPOINT [ "sh", "-c", "./entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+caribou upgrade previous_cards.db ./migrations
+python3 -m src


### PR DESCRIPTION
this pull request creates a file called entrypoint.sh, which runs the caribou migration and then starts the python script. this pull request also modifies the Dockerfile to use the entrypoint instead of running the caribou migration and then starting the python script.

thank you for your attention to this matter.